### PR TITLE
🐛 Fix : 오늘 날짜의 경기 페이지, mixIn 수정

### DIFF
--- a/app/(anon)/game/[game-id]/box-score/components/BoxScoreTable.module.scss
+++ b/app/(anon)/game/[game-id]/box-score/components/BoxScoreTable.module.scss
@@ -1,7 +1,7 @@
 @use 'utils' as *;
 
 .teamTitle {
-  @include flexbox($align: center, $gap: 8);
+  @include flexbox($align: center, $gap: 8px);
 
   span {
     font-weight: 600;

--- a/app/(anon)/game/[game-id]/box-score/page.module.scss
+++ b/app/(anon)/game/[game-id]/box-score/page.module.scss
@@ -1,7 +1,7 @@
 @use 'utils' as *;
 
 .boxScoreContainer {
-  @include flexbox($direction: column, $gap: 24);
+  @include flexbox($direction: column, $gap: 24px);
   width: 100%;
 }
 

--- a/app/(anon)/game/[game-id]/box-score/page.tsx
+++ b/app/(anon)/game/[game-id]/box-score/page.tsx
@@ -6,9 +6,10 @@ import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { fetcher } from '@/utils';
 import { BoxscoreDto } from '@/application/usecases/game/box-score/dto/boxscoreDto';
+import Loader from '@/components/loader/Loader';
 
 const BoxScore = () => {
-  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isLoading, setIsLoading] = useState<boolean>(() => true);
   const [boxscoreData, setBoxscoreData] = useState<BoxscoreDto>();
 
   const params = useParams();
@@ -33,12 +34,7 @@ const BoxScore = () => {
     fetchBoxscore();
   }, [gameId]);
 
-  if (isLoading) return <div style={{ textAlign: 'center' }}>로딩중...</div>;
-  if (!boxscoreData) {
-    return (
-      <div className={styles.scheduledGame}>추후 업데이트 예정입니다.</div>
-    );
-  }
+  if (isLoading || !boxscoreData) return <Loader />;
   if (boxscoreData.game.status === 'scheduled') {
     return (
       <div className={styles.scheduledGame}>경기 시작 후 업데이트 됩니다.</div>

--- a/app/(anon)/game/[game-id]/components/chat/ChatSection.tsx
+++ b/app/(anon)/game/[game-id]/components/chat/ChatSection.tsx
@@ -149,7 +149,9 @@ const ChatSection = ({
               sendMessage();
             }
           }}
+          rows={1}
         />
+
         <button
           className={styles.iconArrowUp}
           disabled={!value}

--- a/app/(anon)/game/[game-id]/components/today/TodayGameSection.module.scss
+++ b/app/(anon)/game/[game-id]/components/today/TodayGameSection.module.scss
@@ -37,3 +37,8 @@
     cursor: not-allowed;
   }
 }
+
+.swiperslide {
+  width: 182px;
+  margin-right: 16px;
+}

--- a/app/(anon)/game/[game-id]/components/today/TodayGameSection.tsx
+++ b/app/(anon)/game/[game-id]/components/today/TodayGameSection.tsx
@@ -180,7 +180,7 @@ const TodayGameSection = () => {
         className={`swiper ${totalCards.length <= 5 ? 'limited-swiper' : 'full-swiper'}`}
       >
         {totalCards.map((data, index) => (
-          <SwiperSlide key={data?.id ?? index}>
+          <SwiperSlide key={data?.id ?? index} className={styles.swiperslide}>
             <TodayGameCard data={data} />
           </SwiperSlide>
         ))}

--- a/app/(anon)/game/[game-id]/components/today/swiper.scss
+++ b/app/(anon)/game/[game-id]/components/today/swiper.scss
@@ -12,8 +12,3 @@
   margin-left: auto;
   margin-right: 0;
 }
-
-.swiper-slide {
-  width: 182px !important;
-  flex-shrink: 0;
-}

--- a/app/(anon)/game/[game-id]/play-by-play/page.tsx
+++ b/app/(anon)/game/[game-id]/play-by-play/page.tsx
@@ -9,6 +9,7 @@ import {
   EventDto,
   PlaybyplayDto,
 } from '@/application/usecases/game/play-by-play/dto/PlaybyplayDto';
+import Loader from '@/components/loader/Loader';
 
 const QUARTERS = ['1Q', '2Q', '3Q', '4Q'];
 
@@ -67,8 +68,8 @@ const PlayByPlay = () => {
     };
   }, [gameId]);
 
-  if (isLoading) return <div>로딩 중...</div>;
-  if (!playByPlayData || playByPlayData.game.status === 'scheduled') {
+  if (isLoading || !playByPlayData) return <Loader />;
+  if (playByPlayData.game.status === 'scheduled') {
     return <p className={styles.statusInfo}>경기 시작 후 업데이트 됩니다.</p>;
   }
 

--- a/app/(anon)/game/[game-id]/play-by-play/page.tsx
+++ b/app/(anon)/game/[game-id]/play-by-play/page.tsx
@@ -109,6 +109,8 @@ const PlayByPlay = () => {
         <tbody>
           {currentQuarterData
             ? currentQuarterData.map((item, index) => {
+                const isPlayingActionType =
+                  item.actionType !== 'game' && item.actionType !== 'period';
                 const type =
                   item.teamId?.toString() === playByPlayData.homeTeam.id
                     ? 'home'
@@ -118,7 +120,7 @@ const PlayByPlay = () => {
                     key={`${item.clock}_${item.edited}_${index}`}
                     type={type}
                     event={item}
-                    isFirst={index === 0}
+                    isFirst={index === 0 && isPlayingActionType}
                   />
                 );
               })

--- a/app/(anon)/game/[game-id]/videos/components/YoutubeVideoCard.module.scss
+++ b/app/(anon)/game/[game-id]/videos/components/YoutubeVideoCard.module.scss
@@ -1,7 +1,7 @@
 @use 'utils' as *;
 
 .videoCard {
-  @include flexbox($direction: column, $gap: 8);
+  @include flexbox($direction: column, $gap: 8px);
   width: 200px;
   color: $color-white;
   transition: transform 0.3s;
@@ -16,7 +16,7 @@
 }
 
 .details {
-  @include flexbox($direction: column, $gap: 4);
+  @include flexbox($direction: column, $gap: 4px);
   padding-left: 4px;
 
   .title {
@@ -26,7 +26,7 @@
   }
 
   .channel {
-    @include flexbox($direction: row, $gap: 4);
+    @include flexbox($direction: row, $gap: 4px);
 
     .channelImage {
       border-radius: $border-radius-circle;

--- a/app/(anon)/game/[game-id]/videos/page.tsx
+++ b/app/(anon)/game/[game-id]/videos/page.tsx
@@ -10,12 +10,13 @@ import {
   YoutubeVideosWithChannelDto,
 } from '@/application/usecases/game/videos/dto/YoutubeVideosDto';
 import { GameDto } from '@/application/usecases/game/videos/dto/GameDto';
+import Loader from '@/components/loader/Loader';
 
 const Videos = () => {
   const [videos, setVideos] = useState<YoutubeVideoDto[] | null>([]);
   const [countVideos, setCountVideos] = useState<number>(12);
   const [gameData, setGameData] = useState<GameDto | null>(null);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isLoading, setIsLoading] = useState<boolean>(() => true);
 
   const params = useParams();
   const gameId = params['game-id'];
@@ -69,7 +70,7 @@ const Videos = () => {
     [isLoading, displayMoreVideos]
   );
 
-  if (isLoading) return <div style={{ textAlign: 'center' }}>로딩중...</div>;
+  if (isLoading) return <Loader />;
   if (!videos || !gameData)
     return <p className={styles.statusInfo}>추후 업데이트 예정입니다.</p>;
 

--- a/app/(anon)/schedule/page.tsx
+++ b/app/(anon)/schedule/page.tsx
@@ -45,7 +45,6 @@ const Schedule = () => {
       const response = await fetcher<ScheduledGameDto[]>(
         `${process.env.NEXT_PUBLIC_API_URL}/schedule/${dayjs(date).format('YYYY-MM-DD')}`
       );
-      console.log(response);
       setScheduledGames(response);
     } catch (error) {
       console.error(error);

--- a/application/usecases/game/box-score/dto/boxscoreDto.ts
+++ b/application/usecases/game/box-score/dto/boxscoreDto.ts
@@ -27,7 +27,7 @@ export interface TeamDto {
   name: string;
   city: string;
   logo: string;
-  players: StatisticsDto[];
+  players: StatisticsDto[] | [];
 }
 
 export interface BoxscoreDto {

--- a/application/usecases/game/box-score/readBoxscoreUsecase.ts
+++ b/application/usecases/game/box-score/readBoxscoreUsecase.ts
@@ -68,13 +68,8 @@ export const readBoxscoreUsecase = async (
       game.status = 'live';
     }
 
-    const statistics = await statisticsRepository.findById(gameId);
-    if (!statistics || statistics.length === 0) {
-      throw new Error('게임 통계 정보를 찾을 수 없습니다.');
-    }
-
-    const homeTeamId = statistics[0].teamId;
-    const awayTeamId = statistics[statistics.length - 1].teamId;
+    const homeTeamId = game.homeTeamId;
+    const awayTeamId = game.awayTeamId;
 
     const homeTeam = await teamRepository.findById(homeTeamId);
     if (!homeTeam) {
@@ -84,6 +79,33 @@ export const readBoxscoreUsecase = async (
     const awayTeam = await teamRepository.findById(awayTeamId);
     if (!awayTeam) {
       throw new Error(`어웨이팀(${awayTeamId}) 정보가 없습니다.`);
+    }
+
+    if (game.status === 'scheduled')
+      return {
+        game: {
+          id: game.id,
+          status: game.status,
+        },
+        homeTeam: {
+          id: homeTeam.id,
+          name: homeTeam.name,
+          city: homeTeam.city,
+          logo: homeTeam.logo,
+          players: [],
+        },
+        awayTeam: {
+          id: awayTeam.id,
+          name: awayTeam.name,
+          city: awayTeam.city,
+          logo: awayTeam.logo,
+          players: [],
+        },
+      };
+
+    const statistics = await statisticsRepository.findById(gameId);
+    if (!statistics || statistics.length === 0) {
+      throw new Error('게임 통계 정보를 찾을 수 없습니다.');
     }
 
     const homePlayers = statistics

--- a/application/usecases/game/box-score/readBoxscoreUsecase.ts
+++ b/application/usecases/game/box-score/readBoxscoreUsecase.ts
@@ -3,6 +3,7 @@ import { BoxscoreDto } from './dto/boxscoreDto';
 import { Statistics } from '@/domain/entities/Statistics';
 import { TeamRepository } from '@/domain/repositories/TeamRepository';
 import { GameRepository } from '@/domain/repositories/GameRepository';
+import convertKSTtoTime from '@/utils/convertKSTtoTimestamp';
 
 const extractMinAndSecFromText = (str: string) => {
   const match = str.match(/PT(\d+)M(\d+)(?:\.\d+)?S/);
@@ -51,13 +52,23 @@ export const readBoxscoreUsecase = async (
   statisticsRepository: StatisticsRepository
 ): Promise<BoxscoreDto> => {
   try {
-    const statistics = await statisticsRepository.findById(gameId);
     const game = await gameRepository.findById(gameId);
 
     if (!game) {
       throw new Error(`게임(${gameId}) 정보가 없습니다.`);
     }
 
+    const currentTime = new Date().getTime();
+    const gameStartTime = convertKSTtoTime(game.startTime);
+    const threeHoursLater = gameStartTime + 3 * 60 * 60 * 1000;
+
+    if (currentTime >= threeHoursLater) {
+      game.status = 'final';
+    } else if (currentTime >= gameStartTime) {
+      game.status = 'live';
+    }
+
+    const statistics = await statisticsRepository.findById(gameId);
     if (!statistics || statistics.length === 0) {
       throw new Error('게임 통계 정보를 찾을 수 없습니다.');
     }

--- a/application/usecases/game/play-by-play/readPlaybyplayUsecase.ts
+++ b/application/usecases/game/play-by-play/readPlaybyplayUsecase.ts
@@ -3,6 +3,7 @@ import { GameRepository } from '@/domain/repositories/GameRepository';
 import { EventDto, PlaybyplayDto } from './dto/PlaybyplayDto';
 import { PlaybyplayRepository } from '@/domain/repositories/PlaybyPlayRepository';
 import { Playbyplay } from '@/domain/entities/Playbyplay';
+import convertKSTtoTime from '@/utils/convertKSTtoTimestamp';
 
 const descriptionKor: Record<string, Record<string, string> | string> = {
   game: {
@@ -75,11 +76,9 @@ export const readPlaybyplayUsecase = async (
       throw new Error(`게임(${gameId}) 정보가 없습니다.`);
     }
 
-    const currentTime = new Date();
-    const gameStartTime = new Date(game.startTime);
-    const threeHoursLater = new Date(
-      gameStartTime.getTime() + 3 * 60 * 60 * 1000
-    );
+    const currentTime = new Date().getTime();
+    const gameStartTime = convertKSTtoTime(game.startTime);
+    const threeHoursLater = gameStartTime + 3 * 60 * 60 * 1000;
 
     if (currentTime >= threeHoursLater) {
       game.status = 'final';

--- a/application/usecases/game/videos/getYoutubeVideosUsecase.ts
+++ b/application/usecases/game/videos/getYoutubeVideosUsecase.ts
@@ -5,6 +5,7 @@ import {
 } from './dto/YoutubeVideosDto';
 import { GameRepository } from '@/domain/repositories/GameRepository';
 import { TeamRepository } from '@/domain/repositories/TeamRepository';
+import convertKSTtoTime from '@/utils/convertKSTtoTimestamp';
 
 export const getYoutubeVideosUsecase = async (
   gameId: string,
@@ -14,6 +15,16 @@ export const getYoutubeVideosUsecase = async (
   const game = await gameRepository.findById(gameId);
   if (!game) {
     throw new Error(`게임(${gameId}) 정보가 없습니다.`);
+  }
+
+  const currentTime = new Date().getTime();
+  const gameStartTime = convertKSTtoTime(game.startTime);
+  const threeHoursLater = gameStartTime + 3 * 60 * 60 * 1000;
+
+  if (currentTime >= threeHoursLater) {
+    game.status = 'final';
+  } else if (currentTime >= gameStartTime) {
+    game.status = 'live';
   }
 
   if (game.status !== 'final') return { game, videos: null };

--- a/utils/convertKSTtoTimestamp.ts
+++ b/utils/convertKSTtoTimestamp.ts
@@ -1,0 +1,12 @@
+const convertKSTtoTime = (KSTdate: string) => {
+  const formattedDate = KSTdate.replace(
+    /(\d{4})\.\s*(\d{2})\.\s*(\d{2})/,
+    '$1-$2-$3'
+  ) // YYYY. MM. DD → YYYY-MM-DD
+    .replace(/\s*AM|\s*PM/, '') // AM/PM 제거 (24시간제로 변환)
+    .replace('KST', '+09:00'); // KST → +09:00
+
+  return new Date(formattedDate).getTime();
+};
+
+export default convertKSTtoTime;


### PR DESCRIPTION
## 제목

BugFix : 오늘 날짜의 경기 페이지, mixIn 수정

## 작업 유형

- [ ] 기능 추가/수정
- [x] 버그 수정
- [ ] 마크업 완성
- [x] 스타일링 완성
- [ ] 코드 리팩토링
- [ ] 코드 스타일 갱신
- [ ] 문서 추가/수정
- [ ] 기타: (작업 유형을 간략하게 작성해주세요.)

## 작업 내용

- 오늘 날짜 경기의 status 확인 로직 추가 (`readPlaybyplayUsecase`, `readBoxscoreUsecase`, `getYoutubeVideosUsecase`)
- KST → Timestamp 변환 함수 추가 (`convertKSTtoTimestamp`)
- scss mixin에 `px` 단위 추가
- Timeline 컴포넌트에 `isPlayingActionType` 조건을 추가해 플레이 관련 내용일 경우에만 애니메이션 적용되도록 수정