### PR TITLE
🐛 fix: 스와이퍼 버튼 작동 개선

### DIFF
--- a/app/(anon)/game/[game-id]/components/today/TodayGameSection.tsx
+++ b/app/(anon)/game/[game-id]/components/today/TodayGameSection.tsx
@@ -8,6 +8,7 @@ import './swiper.scss';
 /* swiper */
 import { Navigation } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
+import type { Swiper as SwiperType } from 'swiper';
 
 import { ScheduledGameDto } from '@/application/usecases/schedule/dto/ScheduledGameDto';
 import Icon from '@/components/icon/Icon';
@@ -48,6 +49,26 @@ const TodayGameSection = () => {
 
   const shouldShowNavigation = todayGames.length > 5;
 
+  const [swiperInstance, setSwiperInstance] = useState<SwiperType | null>(null);
+
+  useEffect(() => {
+    if (
+      swiperInstance &&
+      prevRef.current &&
+      nextRef.current &&
+      typeof swiperInstance.params.navigation !== 'boolean'
+    ) {
+      const navigationParams = swiperInstance.params
+        .navigation as NavigationOptions;
+      navigationParams.prevEl = prevRef.current;
+      navigationParams.nextEl = nextRef.current;
+
+      swiperInstance.navigation.destroy(); // 기존 navigation 제거
+      swiperInstance.navigation.init(); // 새로 init
+      swiperInstance.navigation.update(); // 버튼 갱신
+    }
+  }, [swiperInstance, prevRef.current, nextRef.current, todayGames]);
+
   return (
     <section className={styles.todayGameContainer}>
       <h2>
@@ -72,22 +93,7 @@ const TodayGameSection = () => {
           prevEl: prevRef.current,
           nextEl: nextRef.current,
         }}
-        onSwiper={(swiper) => {
-          setTimeout(() => {
-            if (
-              prevRef.current &&
-              nextRef.current &&
-              typeof swiper.params.navigation !== 'boolean'
-            ) {
-              const navigationParams = swiper.params
-                .navigation as NavigationOptions;
-              navigationParams.prevEl = prevRef.current;
-              navigationParams.nextEl = nextRef.current;
-              swiper.navigation.init();
-              swiper.navigation.update();
-            }
-          });
-        }}
+        onSwiper={setSwiperInstance}
         onSlideChange={(swiper) => {
           setIsLastSlide(swiper.isEnd);
           setIsFirstSlide(swiper.isBeginning);


### PR DESCRIPTION
## 제목

🐛 fix: 스와이퍼 버튼 작동 개선

## 작업 유형

- [ ] 기능 추가/수정
- [x] 버그 수정
- [ ] 마크업 완성
- [ ] 스타일링 완성
- [ ] 코드 리팩토링
- [ ] 코드 스타일 갱신
- [ ] 문서 추가/수정
- [ ] 기타: (작업 유형을 간략하게 작성해주세요.)

## 작업 내용

- Swiper 인스턴스를 상태로 저장해서 useEffect에서 navigation을 초기화하도록 변경
- 기존 setTimeout 제거
- useEffect의 의존성 배열에 todayGames 추가 → 슬라이드 데이터가 렌더링된 이후에 버튼이 정상 작동하도록 개선